### PR TITLE
Fix wrong error code

### DIFF
--- a/Library/AppSrc/JWT/JWT.pkg
+++ b/Library/AppSrc/JWT/JWT.pkg
@@ -326,7 +326,7 @@ Class cBaseJsonWebToken is a cJsonObject
         // Try parse
         Get ParseUtf8 ucaTemp to bOk
         If (not(bOk)) Begin
-            Function_Return False
+            Function_Return C_JWT_INVALID
         End
         
         // Verify is JWT


### PR DESCRIPTION
Fixed a wrong error code, boolean false = 0 and 0 = C_JWT_VALID. Changed it to C_JWT_INVALID because if the JWT cannot be parsed it must be invalid.