### PR TITLE
Audience is now Array based

### DIFF
--- a/Demo/AppSrc/Dashboard.wo
+++ b/Demo/AppSrc/Dashboard.wo
@@ -98,7 +98,8 @@ Object oDashboard is a cWebView
                     Forward Send OnClick
                     Integer iReturnValue
                     String sJWT sReturnValue 
-                    String sSubject sIssuer sAudience
+                    String sSubject sIssuer
+                    String[] saAudience
                     UBigInt ubiIssuedAt ubiExpiration ubiNotBefore
                     
                     WebGet psValue of oWebForm to sJWT
@@ -107,14 +108,17 @@ Object oDashboard is a cWebView
                     
                     Get Subject of oJWT to sSubject
                     Get Issuer of oJWT to sIssuer
-                    Get Audience of oJWT to sAudience
+                    Get Audience of oJWT to saAudience
                     Get IssuedAt of oJWT to ubiIssuedAt
                     Get Expiration of oJWT to ubiExpiration
                     Get NotBefore of oJWT to ubiNotBefore
                     
                     WebSet psValue of oWebForm1 to sSubject
                     WebSet psValue of oWebForm2 to sIssuer
-                    WebSet psValue of oWebForm3 to sAudience
+                    If (SizeOfArray(saAudience) > 1) ;
+                        WebSet psValue of oWebForm3 to (StrJoinFromArray(saAudience, ' '))
+                    Else ;
+                        WebSet psValue of oWebForm3 to saAudience[0]
                     WebSet psValue of oWebForm4 to ubiIssuedAt
                     WebSet psValue of oWebForm5 to ubiExpiration
                     WebSet psValue of oWebForm6 to ubiNotBefore
@@ -236,7 +240,10 @@ Object oDashboard is a cWebView
                     WebGet psValue of oWebForm2 to sValue
                     Set Issuer of oJWT to sValue
                     WebGet psValue of oWebForm3 to sValue
-                    Set Audience of oJWT to sValue
+                    If (Pos(' ', sValue)) ;
+                        Set Audience_Array of oJWT to (StrSplitToArray(sValue, " "))
+                    Else ;
+                        Set Audience of oJWT to sValue
                     WebGet psValue of oWebForm4 to ubiUnixTime
                     Set IssuedAt of oJWT to ubiUnixTime
                     WebGet psValue of oWebForm5 to ubiUnixTime

--- a/Demo/AppSrc/Dashboard.wo
+++ b/Demo/AppSrc/Dashboard.wo
@@ -98,8 +98,7 @@ Object oDashboard is a cWebView
                     Forward Send OnClick
                     Integer iReturnValue
                     String sJWT sReturnValue 
-                    String sSubject sIssuer
-                    String[] saAudience
+                    String sSubject sIssuer sAudience
                     UBigInt ubiIssuedAt ubiExpiration ubiNotBefore
                     
                     WebGet psValue of oWebForm to sJWT
@@ -108,17 +107,14 @@ Object oDashboard is a cWebView
                     
                     Get Subject of oJWT to sSubject
                     Get Issuer of oJWT to sIssuer
-                    Get Audience of oJWT to saAudience
+                    Get Audience of oJWT to sAudience
                     Get IssuedAt of oJWT to ubiIssuedAt
                     Get Expiration of oJWT to ubiExpiration
                     Get NotBefore of oJWT to ubiNotBefore
                     
                     WebSet psValue of oWebForm1 to sSubject
                     WebSet psValue of oWebForm2 to sIssuer
-                    If (SizeOfArray(saAudience) > 1) ;
-                        WebSet psValue of oWebForm3 to (StrJoinFromArray(saAudience, ' '))
-                    Else ;
-                        WebSet psValue of oWebForm3 to saAudience[0]
+                    WebSet psValue of oWebForm3 to sAudience
                     WebSet psValue of oWebForm4 to ubiIssuedAt
                     WebSet psValue of oWebForm5 to ubiExpiration
                     WebSet psValue of oWebForm6 to ubiNotBefore
@@ -240,10 +236,7 @@ Object oDashboard is a cWebView
                     WebGet psValue of oWebForm2 to sValue
                     Set Issuer of oJWT to sValue
                     WebGet psValue of oWebForm3 to sValue
-                    If (Pos(' ', sValue)) ;
-                        Set Audience_Array of oJWT to (StrSplitToArray(sValue, " "))
-                    Else ;
-                        Set Audience of oJWT to sValue
+                    Set Audience of oJWT to sValue
                     WebGet psValue of oWebForm4 to ubiUnixTime
                     Set IssuedAt of oJWT to ubiUnixTime
                     WebGet psValue of oWebForm5 to ubiUnixTime

--- a/Library/AppSrc/JWT/JWT.pkg
+++ b/Library/AppSrc/JWT/JWT.pkg
@@ -326,7 +326,7 @@ Class cBaseJsonWebToken is a cJsonObject
         // Try parse
         Get ParseUtf8 ucaTemp to bOk
         If (not(bOk)) Begin
-            Function_Return False
+            Function_Return C_JWT_INVALID
         End
         
         // Verify is JWT

--- a/Library/AppSrc/JWT/JWT.pkg
+++ b/Library/AppSrc/JWT/JWT.pkg
@@ -185,9 +185,40 @@ Class cBaseJsonWebToken is a cJsonObject
         Send SetMemberValue "aud" jsonTypeString sValue 
     End_Procedure
     { MethodType=Property }
-    Function Audience Returns String
+    Procedure Set Audience_Array String[] saValues
+        String sValue
+        Boolean bSuccess
+        Handle hoTempJson
+        Get StrJoinFromArray saValues '","' to sValue
+        Move ('["' - sValue - '"]') to sValue
+        Get Create (RefClass(cJsonObject)) to hoTempJson
+        Send InitializeJsonType of hoTempJson jsonTypeArray
+        Get ParseString of hoTempJson sValue to bSuccess
+        If (bSuccess) ;
+            Send SetMember "aud" hoTempJson 
+        Send Destroy of hoTempJson
+    End_Procedure
+    { MethodType=Property }
+    Function Audience Returns String[]
+        Integer iJsonTypeMember
+        String sMemberValue
+        String[] saMemberValue
+        Handle hoMember
+        
         If (not(HasMember(Self, "aud"))) Function_Return ""
-        Function_Return (MemberValue(Self, "aud"))
+        Get MemberValue "aud" to sMemberValue
+        Get MemberJsonType  "aud" to iJsonTypeMember
+        If (iJsonTypeMember = jsonTypeArray) Begin
+            Move (Replace('[ "', sMemberValue, '')) to sMemberValue
+            Move (Replace('" ]', sMemberValue, '')) to sMemberValue
+            Get StrSplitToArray sMemberValue '", "' to saMemberValue
+            Function_Return saMemberValue
+        End
+        Else If (iJsonTypeMember = jsonTypeString) Begin
+            Move sMemberValue to saMemberValue[0]
+            Function_Return saMemberValue
+        End
+        Else Function_Return saMemberValue //Empty
     End_Function
     
     { MethodType=Property }

--- a/Library/AppSrc/JWT/JWT.pkg
+++ b/Library/AppSrc/JWT/JWT.pkg
@@ -180,26 +180,32 @@ Class cBaseJsonWebToken is a cJsonObject
         Function_Return (MemberValue(Self, "sub"))
     End_Function
     
+    //If the audience is a space separated string, then it would be a JSON Array, otherwise just a String.
     { MethodType=Property }
     Procedure Set Audience String sValue
-        Send SetMemberValue "aud" jsonTypeString sValue 
-    End_Procedure
-    { MethodType=Property }
-    Procedure Set Audience_Array String[] saValues
-        String sValue
+        String sTempString
         Boolean bSuccess
         Handle hoTempJson
-        Get StrJoinFromArray saValues '","' to sValue
-        Move ('["' - sValue - '"]') to sValue
-        Get Create (RefClass(cJsonObject)) to hoTempJson
-        Send InitializeJsonType of hoTempJson jsonTypeArray
-        Get ParseString of hoTempJson sValue to bSuccess
-        If (bSuccess) ;
-            Send SetMember "aud" hoTempJson 
-        Send Destroy of hoTempJson
+        String[] saAudience
+        
+        If (Pos(' ', sValue)) Begin
+            Move (StrSplitToArray(sValue, " ")) to saAudience
+            If (SizeOfArray(saAudience) > 0) Begin
+                Get StrJoinFromArray saAudience '","' to sTempString
+                Move ('["' - sTempString - '"]') to sTempString
+                Get Create (RefClass(cJsonObject)) to hoTempJson
+                Send InitializeJsonType of hoTempJson jsonTypeArray
+                Get ParseString of hoTempJson sTempString to bSuccess
+                If (bSuccess) ;
+                    Send SetMember "aud" hoTempJson 
+                Send Destroy of hoTempJson
+            End
+        End
+        Else ;
+            Send SetMemberValue "aud" jsonTypeString sValue 
     End_Procedure
     { MethodType=Property }
-    Function Audience Returns String[]
+    Function Audience Returns String
         Integer iJsonTypeMember
         String sMemberValue
         String[] saMemberValue
@@ -207,18 +213,19 @@ Class cBaseJsonWebToken is a cJsonObject
         
         If (not(HasMember(Self, "aud"))) Function_Return ""
         Get MemberValue "aud" to sMemberValue
+        
         Get MemberJsonType  "aud" to iJsonTypeMember
         If (iJsonTypeMember = jsonTypeArray) Begin
             Move (Replace('[ "', sMemberValue, '')) to sMemberValue
             Move (Replace('" ]', sMemberValue, '')) to sMemberValue
             Get StrSplitToArray sMemberValue '", "' to saMemberValue
-            Function_Return saMemberValue
+            Function_Return (StrJoinFromArray(saMemberValue, ' '))
         End
         Else If (iJsonTypeMember = jsonTypeString) Begin
-            Move sMemberValue to saMemberValue[0]
-            Function_Return saMemberValue
+            Function_Return sMemberValue
         End
-        Else Function_Return saMemberValue //Empty
+        Else ;
+            Function_Return ""
     End_Function
     
     { MethodType=Property }

--- a/Library/AppSrc/JWT/l8w8jwt2_mixin.pkg
+++ b/Library/AppSrc/JWT/l8w8jwt2_mixin.pkg
@@ -166,12 +166,6 @@ Class cL8w8jwt_Mixin is a Mixin
             Move (AddressOf(sIss)) to stl8w8jwt_encoding_params.iss
             Move (SizeOfString(sIss)) to stl8w8jwt_encoding_params.iss_length
         End
-        //Aud
-        If (HasMember(hoJsonWebToken, 'aud')) Begin          
-            Get MemberValue of hoJsonWebToken 'aud' to sAud
-            Move (AddressOf(sAud)) to stl8w8jwt_encoding_params.aud
-            Move (SizeOfString(sAud)) to stl8w8jwt_encoding_params.aud_length
-        End
         //JTI
         If (HasMember(hoJsonWebToken, 'jti')) Begin          
             Get MemberValue of hoJsonWebToken 'jti' to sJti
@@ -204,8 +198,17 @@ Class cL8w8jwt_Mixin is a Mixin
         Move (AddressOf(pJWTResult)) to stl8w8jwt_encoding_params.out
         Move (AddressOf(iSizeOfJWTResult)) to stl8w8jwt_encoding_params.out_length
         
+        Move (StrSplitToArray("sub,iss,iat,exp,nbf", ',')) to saBlacklistMembers
+        //Aud
+        If (HasMember(hoJsonWebToken, 'aud')) Begin          
+            Get MemberValue of hoJsonWebToken 'aud' to sAud
+            If (not(Pos('[', sAud) > 0 or Pos(']', sAud) > 0)) Begin
+                Move (AddressOf(sAud)) to stl8w8jwt_encoding_params.aud
+                Move (SizeOfString(sAud)) to stl8w8jwt_encoding_params.aud_length
+                Move 'aud' to saBlacklistMembers[SizeOfArray(saBlacklistMembers)]
+            End
+        End
         //Additional claims
-        Move (StrSplitToArray("sub,iss,aud,iat,exp,nbf", ',')) to saBlacklistMembers
         Move (SortArray(saBlacklistMembers)) to saBlacklistMembers
         Move 0  to iClaimsCounter
         


### PR DESCRIPTION
Audience is now array based so that it can contain multiple audiences.

There is a short coming in the library that we cannot give an array along in the standard encoding parameters. If we would do that, it would always string escape it with some extra double quotes. The work around here is not to add it as an standard parameter but as a "additional claim". This way we would dynamically set the parameter the right way and the output is correct.