### PR TITLE
Fix/header typ values

### DIFF
--- a/Library/AppSrc/JWT/JWT.pkg
+++ b/Library/AppSrc/JWT/JWT.pkg
@@ -372,7 +372,7 @@ Class cBaseJsonWebToken is a cJsonObject
         If (not(HasMember(Self, "typ"))) Begin
             Function_Return C_JWT_NOT_A_JWT
         End
-        If (MemberValue(Self, "typ") <> "JWT") Begin
+        If (not(MemberValue(Self, "typ") contains "JWT")) Begin
             Function_Return C_JWT_NOT_A_JWT
         End
         

--- a/Library/AppSrc/JWT/JWT.pkg
+++ b/Library/AppSrc/JWT/JWT.pkg
@@ -372,7 +372,7 @@ Class cBaseJsonWebToken is a cJsonObject
         If (not(HasMember(Self, "typ"))) Begin
             Function_Return C_JWT_NOT_A_JWT
         End
-        If (not(MemberValue(Self, "typ") contains "JWT")) Begin
+        If (not(Lowercase(MemberValue(Self, "typ")) contains "jwt")) Begin
             Function_Return C_JWT_NOT_A_JWT
         End
         


### PR DESCRIPTION
There are a lot more valid typ values that result in a `C_JWT_NOT_A_JWT` result but that should not be the case. For one of my projects we use an identity server that uses OpenIddict, this is a .NET OpenID stack. OpenIddict gives us access tokens with type at+JWT which stands for access token JWT, this is a legit type that should be supported by the JWT library.